### PR TITLE
Attempt to fix crashes on edits for duplicate translations.

### DIFF
--- a/wagtail_localize/views/edit_translation.py
+++ b/wagtail_localize/views/edit_translation.py
@@ -886,7 +886,9 @@ def edit_translation(request, translation, instance):
                 .exclude(pk=instance.pk)
                 .exists()
             )
-        except (TranslationSource.DoesNotExist, IndexError):
+        except (
+            TranslationSource.DoesNotExist, IndexError, TranslationSource.MultipleObjectsReturned
+        ):
             add_convert_to_alias_url = False
     else:
         add_convert_to_alias_url = False

--- a/wagtail_localize/wagtail_hooks.py
+++ b/wagtail_localize/wagtail_hooks.py
@@ -253,7 +253,9 @@ def before_edit_page(request, page):
     if request.method == "POST":
         if "localize-restart-translation" in request.POST:
             try:
-                translation = Translation.objects.get(
+                translation = Translation.objects.exclude(
+                    source__locale_id=page.locale_id
+                ).get(
                     source__object_id=page.translation_key,
                     target_locale_id=page.locale_id,
                     enabled=False,


### PR DESCRIPTION
So - we ended up with the weird "Spanish translation of Spanish Original" mess.

We can:

1. Fix the bug that created this situation
2. Fix the data to remove the invalid data
3. Make it so that if this kind of nonsense happens again, it at least doesn't crash.

This PR is the Part 3.

Part 2 is a couple of SQL queries, and happens instantly.

Part 1 requires probably more investigation & fixing stuff in wagtail_localize.